### PR TITLE
Fix terraform modules for redshift cluster creation

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,12 +1,14 @@
 resource "aws_redshift_cluster" "feast_redshift_cluster" {
   cluster_identifier = "${var.project_name}-redshift-cluster"
-  iam_roles = ["AWSServiceRoleForRedshift", aws_iam_role.s3_spectrum_role.name]
+  iam_roles = [data.aws_iam_role.AWSServiceRoleForRedshift.arn, aws_iam_role.s3_spectrum_role.arn]
   database_name = var.database_name
   master_username = var.admin_user
   master_password = var.admin_password
   node_type = var.node_type
   cluster_type = var.cluster_type
   number_of_nodes = var.nodes
+
+  skip_final_snapshot = true
 }
 
 resource "aws_s3_bucket" "feast_bucket" {
@@ -14,22 +16,25 @@ resource "aws_s3_bucket" "feast_bucket" {
   acl = "private"
 }
 
+data "aws_iam_role" "AWSServiceRoleForRedshift" {
+  name = "AWSServiceRoleForRedshift"
+}
+
 resource "aws_iam_role" "s3_spectrum_role" {
   name = "s3_spectrum_role"
 
   assume_role_policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "redshift.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
 }
 EOF
 }


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

- The role ARNs need to be specified when creating the Redshift cluster, not the names
- Principal for the redhift IAM role needs to be `redshift.amazonaws.com`.
- Note - this role doesn't support `UNLOAD` commands since it only has Read access to S3.